### PR TITLE
Install the missing dependencies in publish workflow

### DIFF
--- a/.github/workflows/publish_python.yml
+++ b/.github/workflows/publish_python.yml
@@ -19,6 +19,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install -r requirements.txt
         pip install setuptools wheel twine
     - name: Build and publish
       env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project follows [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Fix description text on PyPI
 
 ## [0.0.3] - 2020-06-10
 ### Fixed


### PR DESCRIPTION
if those dependencies are missing, the README markdown can't be properly
    converted to RST, which is needed for PyPI.