### PR TITLE
Directly provide README.md to PyPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project follows [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Remove dependencies to convert md to rst
+- Directly provide markdown to PyPI
 
 ## [0.0.4] - 2020-06-10
 ### Fixed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
 requests
 defusedxml
-pypandoc
-Unidecode

--- a/setup.py
+++ b/setup.py
@@ -11,14 +11,8 @@ with open('sruthi/__init__.py', 'r') as fd:
 if not version:
     raise RuntimeError('Cannot find version information')
 
-try:
-    import pypandoc
-    from unidecode import unidecode
-    description = open('README.md', encoding='utf-8').read()
-    description = unidecode(description)
-    description = pypandoc.convert_text(description, 'rst', format='md')
-except (IOError, OSError, ImportError):
-    description = 'SRU client for Python'
+with open('README.md', 'r', encoding="utf-8") as f:
+    long_description = f.read()
 
 setup(
     name='sruthi',
@@ -26,7 +20,8 @@ setup(
     version=version,
     install_requires=['requests', 'defusedxml'],
     description='SRU client for Python',
-    long_description=description,
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     author='Stefan Oderbolz',
     author_email='odi@metaodi.ch',
     maintainer='Stefan Oderbolz',


### PR DESCRIPTION
previouls PyPI only supported RST, so the text needed to be converted
from md to rst. This is no longer required.