### PR TITLE
Letting the user specify the keyword to use when searching

### DIFF
--- a/sruthi/client.py
+++ b/sruthi/client.py
@@ -12,9 +12,9 @@ class Client(object):
         self.maximum_records = maximum_records
         self.sru_version = '1.2'
 
-    def searchretrieve(self, query, start_record=1):
+    def searchretrieve(self, query, start_record=1, operation='searchretrieve'):
         params = {
-            'operation': 'searchretrieve',
+            'operation': operation,
             'version': self.sru_version,
             'query': query,
             'startRecord': start_record,

--- a/sruthi/sru.py
+++ b/sruthi/sru.py
@@ -3,9 +3,9 @@
 from . import client
 
 
-def searchretrieve(url, query):
+def searchretrieve(url, query, operation='searchretrieve'):
     c = client.Client(url)
-    return c.searchretrieve(query)
+    return c.searchretrieve(query, operation=operation)
 
 
 def explain(url):


### PR DESCRIPTION
Fixing #26 

Here is a trace:
```
In [3]: records = sruthi.searchretrieve('https://suche.staatsarchiv.djiktzh.ch/SRU/', query='Zurich')

In [4]: pprint.pprint(records)
SearchRetrieveResponse(sru_version='1.2',count=500,next_start_record=11)

In [5]: records = sruthi.searchretrieve('http://catalogue.bnf.fr/api/SRU', query='bib.isbn="9782412049402"', operation="sea
   ...: rchRetrieve")

In [6]: pprint.pprint(records)
SearchRetrieveResponse(sru_version='1.2',count=1,next_start_record=None)
```