### PR TITLE
Add support for additional parameters on the client level

### DIFF
--- a/sruthi/client.py
+++ b/sruthi/client.py
@@ -7,11 +7,12 @@ from . import response
 
 
 class Client(object):
-    def __init__(self, url=None, maximum_records=10, record_schema=None, sru_version='1.2'):
+    def __init__(self, url=None, maximum_records=10, record_schema=None, sru_version='1.2', additional_params=None):
         self.url = url
         self.maximum_records = maximum_records
         self.sru_version = sru_version
         self.record_schema = record_schema
+        self.additional_params = additional_params
 
     def searchretrieve(self, query, start_record=1, requests_kwargs=None):
         params = {
@@ -21,6 +22,9 @@ class Client(object):
             'startRecord': start_record,
             'maximumRecords': self.maximum_records,
         }
+
+        if self.additional_params:
+            params.update(self.additional_params)
 
         if self.record_schema:
             params['recordSchema'] = self.record_schema


### PR DESCRIPTION
Some SRU interfaces need additional URL parameters to work. This is at least the case for the SRU interface of KB (Netherlands National Library), which needs the parameter `x-collection=GGC` to work, as here:

http://jsru.kb.nl/sru?version=1.2&operation=searchRetrieve&x-collection=GGC&stylesheet=&recordSchema=dcx&startRecord=1&maximumRecords=10&query=gruninger

This pull request adds support for additional parameters by passing them on to the `Client` constructor. In a project of the Centre for Digital Humanities of Utrecht University we are using sruthi to create a virtual research environments that lets the user query various library databases, including databases with a SRU API.

An alternative to my approach would be to allow passing additional parameters to the `searchretrieve` method; however, as far as I have seen so far the additional parameters remain the same across search/retrieve operations.

I have not included a test with fixture for now, because I would first like to hear if you agree with the approach. I have not provided documentation, because I don't see how to fit this into the current readme file. But please let me know if you would like me to.